### PR TITLE
Make in-memory database work for test configuration

### DIFF
--- a/test/TestDataConfig.java
+++ b/test/TestDataConfig.java
@@ -22,7 +22,7 @@ public class TestDataConfig extends DataConfig {
     public DataSource dataSource() {
         final DriverManagerDataSource dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.h2.Driver");
-        dataSource.setUrl("jdbc:h2:testdb"); // todo: why doesn't in-memory work here?
+        dataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
         return dataSource;
     }
     


### PR DESCRIPTION
The key to making this work was to append ;DB_CLOSE_DELAY=-1 onto the end of the database url.
